### PR TITLE
Move contact_lists stream to v3 API

### DIFF
--- a/tap_hubspot/schemas/contact_lists.json
+++ b/tap_hubspot/schemas/contact_lists.json
@@ -1,97 +1,18 @@
 {
     "type": "object",
     "properties": {
-        "parentId": {
-            "type": ["null", "integer"]
-        },
-        "metaData": {
-            "type": "object",
-            "properties": {
-                "processing": {
-                    "type": ["null", "string"]
-                },
-                "size": {
-                    "type": ["null", "integer"]
-                },
-                "error": {
-                    "type": ["null", "string"]
-                },
-                "lastProcessingStateChangeAt": {
-                    "type": ["null", "string"],
-                    "format": "date-time"
-                },
-                "lastSizeChangeAt": {
-                    "type": ["null", "string"],
-                    "format": "date-time"
-                }
-            }
-        },
-        "dynamic": {
-            "type": ["null", "boolean"]
-        },
-        "name": {
-            "type": ["null", "string"]
-        },
-        "filters": {
-            "type": "array",
-            "items": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "filterFamily": {
-                            "type": ["null", "string"]
-                        },
-                        "withinTimeMode": {
-                            "type": ["null", "string"]
-                        },
-                        "checkPastVersions": {
-                            "type": ["null", "boolean"]
-                        },
-                        "type": {
-                            "type": ["null", "string"]
-                        },
-                        "property": {
-                            "type": ["null", "string"]
-                        },
-                        "value": {
-                            "type": ["null", "string"]
-                        },
-                        "operator": {
-                            "type": ["null", "string"]
-                        }
-                    }
-                }
-            }
-        },
-        "portalId": {
-            "type": ["null", "integer"]
-        },
-        "createdAt": {
-            "type": ["null", "string"],
-            "format": "date-time"
-        },
-        "listId": {
-            "type": ["null", "integer"]
-        },
-        "updatedAt": {
-            "type": ["null", "string"],
-            "format": "date-time"
-        },
-        "internalListId": {
-            "type": ["null", "integer"]
-        },
-        "readOnly": {
-            "type": ["null", "boolean"]
-        },
-        "deleteable": {
-            "type": ["null", "boolean"]
-        },
-        "listType": {
-            "type": ["null", "string"]
-        },
-        "archived": {
-            "type": ["null", "boolean"]
-        }
+        "processingType": {"type": ["null", "string"]},
+        "objectTypeId": {"type": ["null", "string"]},
+        "updatedById": {"type": ["null", "integer"]},
+        "filtersUpdatedAt": {"type": ["null", "string"], "format": "date-time"},
+        "listId": {"type": ["null", "string"]},
+        "createdAt": {"type": ["null", "string"], "format": "date-time"},
+        "processingStatus": {"type": ["null", "string"]},
+        "deletedAt": {"type": ["null", "string"], "format": "date-time"},
+        "listVersion": {"type": ["null", "integer"]},
+        "name": {"type": ["null", "string"]},
+        "additionalProperties": {"type": ["null", "object"]},
+        "createdById": {"type": ["null", "integer"]},
+        "updatedAt": {"type": ["null", "string"], "format": "date-time"}
     }
 }


### PR DESCRIPTION
## Summary
- use the new v3 `/crm/v3/lists/search` endpoint
- update contact lists schema for v3

## Testing
- `pip install -e .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tap_tester')*

------
https://chatgpt.com/codex/tasks/task_e_684b1138ee34832085cffb6fea236f0f