### PR TITLE
Add Private App token auth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,30 @@ This tap:
 
 ## Configuration
 
-This tap requires a `config.json` which specifies details regarding [OAuth 2.0](https://developers.hubspot.com/docs/methods/oauth2/oauth2-overview) authentication, a cutoff date for syncing historical data, an optional parameter request_timeout for which request should wait to get the response and an optional flag which controls collection of anonymous usage metrics. See [config.sample.json](config.sample.json) for an example. You may specify an API key instead of OAuth parameters for development purposes, as detailed below.
+This tap requires a `config.json` which specifies details regarding authentication, either via [OAuth 2.0](https://developers.hubspot.com/docs/methods/oauth2/oauth2-overview) or a Private App personal access token (PAT). It also includes a cutoff date for syncing historical data, an optional parameter `request_timeout` and a flag which controls collection of anonymous usage metrics. See [config.sample.json](config.sample.json) for an example. You may specify an API key instead of OAuth parameters for development purposes, as detailed below.
 
 To run `tap-hubspot` with the configuration file, use this command:
 
 ```bash
 › tap-hubspot -c my-config.json
 ```
+
+### Private App PAT Authentication
+
+To use a HubSpot Private App token, set `auth_method` to `pat` and provide your
+token via the `access_token` field:
+
+```json
+{
+  "auth_method": "pat",
+  "access_token": "pat-123",
+  "start_date": "2023-01-01T00:00:00Z"
+}
+```
+
+Environment variables such as `TAP_HUBSPOT_AUTH_METHOD` and
+`TAP_HUBSPOT_ACCESS_TOKEN` may also be used in place of values in the config
+file.
 
 
 ## API Key Authentication (for development)

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,4 +1,5 @@
 {
+  "auth_method": "oauth",
   "redirect_uri": "https://api.hubspot.com/",
   "client_id": 123456789000,
   "client_secret": "my_secret",

--- a/tap_hubspot/tests/unittests/test_auth_method.py
+++ b/tap_hubspot/tests/unittests/test_auth_method.py
@@ -1,0 +1,32 @@
+import unittest
+import datetime
+from unittest.mock import patch
+import tap_hubspot
+
+class TestAuthMethod(unittest.TestCase):
+    def test_pat_headers(self):
+        tap_hubspot.CONFIG.update({
+            "auth_method": "pat",
+            "access_token": "pat-123",
+            "hapikey": None,
+        })
+        params, headers = tap_hubspot.get_params_and_headers({})
+        self.assertEqual(headers.get("Authorization"), "Bearer pat-123")
+
+    @patch('tap_hubspot.acquire_access_token_from_refresh_token')
+    def test_oauth_header_refresh(self, mock_refresh):
+        def _set_token():
+            tap_hubspot.CONFIG['access_token'] = 'newtoken'
+            tap_hubspot.CONFIG['token_expires'] = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        mock_refresh.side_effect = _set_token
+        tap_hubspot.CONFIG.update({
+            "auth_method": "oauth",
+            "access_token": "old",
+            "token_expires": datetime.datetime.utcnow() - datetime.timedelta(seconds=1),
+            "hapikey": None,
+        })
+        params, headers = tap_hubspot.get_params_and_headers({})
+        mock_refresh.assert_called_once()
+        self.assertEqual(headers.get("Authorization"), f"Bearer {tap_hubspot.CONFIG['access_token']}")
+
+


### PR DESCRIPTION
## Summary
- add `auth_method` and token validation
- support env vars for config
- honor PAT authentication in request headers
- document PAT usage
- provide updated config sample
- test headers for PAT and OAuth

## Testing
- `pytest tap_hubspot/tests/unittests/test_auth_method.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68519c5f94d08320aec762d1566d053d